### PR TITLE
Fix problem downloading images.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tumblr-image-downloader",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tumblr-image-downloader",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Contains tools for downloading images from Tumblr blogs",
   "main": "src/index.js",
   "bin": {

--- a/src/launch.js
+++ b/src/launch.js
@@ -124,11 +124,11 @@ async function download(argv, nconf, logs) {
 
                 await downloader.login(username, password);
 
-                logs.info(`login success beginning download of blog "${blogSubdomain}"`);
+                logs.info(`login as ${username} success beginning download of blog "${blogSubdomain}"`);
 
                 let skipExistingFilter = (photo) => {
                     let photoPath = getPhotoPath(dir, photo);
-                    if (fs.existsSync(dir, photo)) {
+                    if (fs.existsSync(photoPath)) {
                         logs.debug(`photo "${photo.photoId}" has already been saved to "${photoPath}". skipping`);
                         return false;
                     }


### PR DESCRIPTION
- Fix fs.existsSync to use the photoPath, instead of the dir and a photo object.
  - This was preventing all downloads since arg 0 (dir) always exists.
- Add username to login info message.
  - To help debugging -- make sure the correct username was being used.